### PR TITLE
Add ChatGPT assistant integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 # climate-game
 
-Este proyecto contiene un juego de ejemplo llamado **Tangible Climate**. Para iniciarlo, ejecuta:
+Este proyecto contiene un juego de ejemplo llamado **Tangible Climate**.
+
+## Uso local
+
+Para probar la versión local simple ejecuta:
 
 ```bash
 python game.py
 ```
 
-Al ejecutarlo verás un mensaje de bienvenida y, a continuación,
-el juego esperará que introduzcas cualquier palabra.
+Esto mostrará un breve mensaje de bienvenida.
+
+## Integración con ChatGPT
+
+El archivo `chat_assistant.py` permite jugar utilizando la API de OpenAI para generar las respuestas de la IA Científica. Para utilizarlo es necesario definir la variable de entorno `OPENAI_API_KEY` con una clave válida.
+
+```bash
+export OPENAI_API_KEY=tu_clave
+python chat_assistant.py
+```
+
+El script cargará la configuración desde `esqueleto_cambio_climatico.json` y las instrucciones de `instrucciones_esqueleto.txt` para iniciar la conversación.

--- a/chat_assistant.py
+++ b/chat_assistant.py
@@ -1,0 +1,56 @@
+import json
+import os
+import openai
+
+
+def load_game_data(json_path: str, txt_path: str):
+    """Load game skeleton data and developer instructions."""
+    with open(json_path, "r", encoding="utf-8") as f:
+        game_data = json.load(f)
+    with open(txt_path, "r", encoding="utf-8") as f:
+        instructions = f.read()
+    return game_data, instructions
+
+
+def build_system_prompt(game_data: dict, instructions: str, language: str = "es") -> str:
+    """Combine the text and JSON content into a single system prompt."""
+    intro = game_data.get("introduccion", "")
+    characters = "\n".join(
+        f"- {c['nombre']}: {c['descripcion']}" for c in game_data.get("personajes", [])
+    )
+    return (
+        f"{instructions}\n\n"
+        f"{intro}\n\n"
+        f"Personajes:\n{characters}\n\n"
+        f"Responde en {language}. Inicia el juego actuando como la IA Científica, "
+        "guiando al Jugador."
+    )
+
+
+def chat_with_assistant(system_prompt: str, model: str = "gpt-3.5-turbo") -> None:
+    """Launch an interactive chat session using OpenAI API."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+    openai.api_key = api_key
+
+    messages = [{"role": "system", "content": system_prompt}]
+    while True:
+        try:
+            user_input = input("You: ")
+        except EOFError:
+            print()
+            break
+        if user_input.lower() in {"salir", "exit", "quit"}:
+            break
+        messages.append({"role": "user", "content": user_input})
+        response = openai.ChatCompletion.create(model=model, messages=messages)
+        reply = response.choices[0].message.content
+        print(f"Assistant: {reply}")
+        messages.append({"role": "assistant", "content": reply})
+
+
+if __name__ == "__main__":
+    data, notes = load_game_data("esqueleto_cambio_climatico.json", "instrucciones_esqueleto.txt")
+    prompt = build_system_prompt(data, notes, language="es")
+    chat_with_assistant(prompt)


### PR DESCRIPTION
## Summary
- add `chat_assistant.py` to integrate with OpenAI API
- document how to run the assistant in `README.md`

## Testing
- `python -m py_compile chat_assistant.py`
- `python -m py_compile game.py`


------
https://chatgpt.com/codex/tasks/task_e_6886a6af3c988332a5dd3a61c69d308d